### PR TITLE
Fix 'jobserver' warning and module path

### DIFF
--- a/test/component.mk
+++ b/test/component.mk
@@ -33,7 +33,8 @@ endif
 APP_CFLAGS += -DRESTART_DELAY=$(RESTART_DELAY)
 
 define BuildAndRun
-$(MAKE) snap-clean && MODULE="$1.$3" $(MAKE) JERRY_COMPACT_PROFILE=$2 SMING_RELEASE=$4 run
++$(MAKE) snap-clean
++$(MAKE) MODULE="$(patsubst %/test,%/,$(MODULE))$1.$3" JERRY_COMPACT_PROFILE=$2 SMING_RELEASE=$4 run
 endef
 
 .PHONY: execute


### PR DESCRIPTION
This PR tweaks the MODULE value so tests appear as `Libraries/jerryscript/es.next.release` instead of overwriting with just `es.next.release` in main Sming CI run.

The jobserver warning is also removed so build can be done in paralllel.
