### PR TITLE
Deduce parameter count in macros

### DIFF
--- a/samples/Basic_Context/app/application.cpp
+++ b/samples/Basic_Context/app/application.cpp
@@ -34,7 +34,7 @@ public:
 protected:
 	bool triggerEvent(const String& name, const JS::Object& params);
 
-	JS_DEFINE_METHOD(addEventListener, 2, JS::Value& eventName, JS::Callable& function)
+	JS_DEFINE_METHOD(addEventListener, JS::Value& eventName, JS::Callable& function)
 	{
 		debug_i("%s.addListener('%s', %p)", getName().c_str(), String(eventName).c_str(), function.get());
 		events[eventName].add(function);

--- a/samples/Event_Jsvm/app/application.cpp
+++ b/samples/Event_Jsvm/app/application.cpp
@@ -30,7 +30,7 @@ IMPORT_FSTR(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
  * @endcode
  *
  */
-JS_DEFINE_FUNCTION(addEventListener, 2, JS::Value& eventName, JS::Callable& function)
+JS_DEFINE_FUNCTION(addEventListener, JS::Value& eventName, JS::Callable& function)
 {
 	if(!eventName.isString() || !function.isCallable()) {
 		return JS::ArgumentError(__FUNCTION__);

--- a/src/include/Jerryscript/Context.h
+++ b/src/include/Jerryscript/Context.h
@@ -30,7 +30,6 @@
 /**
  * @brief Argument list is fixed
  * @param method Name of jerryscript wrapper function
- * @param num_args Number of arguments (cannot be deduced)
  * @param ... Argument definitions
  *
  * Example:
@@ -55,17 +54,17 @@
  * };
  * ```
  */
-#define JS_DEFINE_METHOD(method, num_args, ...)                                                                        \
+#define JS_DEFINE_METHOD(method, ...)                                                                                  \
 	static jerry_value_t method(const jerry_call_info_t* call_info_p, const jerry_value_t args[],                      \
 								const jerry_length_t args_count)                                                       \
 	{                                                                                                                  \
 		using Method = JS::Value (ContextClass::*)(const jerry_call_info_t*, ...);                                     \
-		if(num_args != args_count) {                                                                                   \
+		if(JS_NARG(__VA_ARGS__) != args_count) {                                                                       \
 			return JS::create_arg_count_error(__FUNCTION__);                                                           \
 		}                                                                                                              \
 		auto& ctx = getCurrent();                                                                                      \
 		auto m = reinterpret_cast<Method>(&ContextClass::js_##method);                                                 \
-		auto res = (ctx.*m)(call_info_p JS_ARGS_##num_args);                                                           \
+		auto res = (ctx.*m)(call_info_p JS_CONCAT(JS_ARGS_, JS_NARG(__VA_ARGS__)));                                    \
 		return res.release();                                                                                          \
 	}                                                                                                                  \
 	Jerryscript::Value js_##method(const JS::CallInfo& callInfo, ##__VA_ARGS__)

--- a/src/jsvm-ext.cpp
+++ b/src/jsvm-ext.cpp
@@ -12,7 +12,7 @@
 #include "jsvm-ext.h"
 #include <m_printf.h>
 
-JS_DEFINE_FUNCTION(alertFunction, 1, JS::Value& str)
+JS_DEFINE_FUNCTION(alertFunction, JS::Value& str)
 {
 	String s = str.toString();
 	m_puts("\x1b[1;31m");

--- a/test/modules/context.cpp
+++ b/test/modules/context.cpp
@@ -19,7 +19,7 @@ public:
 
 protected:
 	// This gets invoked when we run the javascriopt 'test' function
-	JS_DEFINE_METHOD(callback, 1, JS::Value& param)
+	JS_DEFINE_METHOD(callback, JS::Value& param)
 	{
 		JS::global()["result"] = param;
 		return true;

--- a/test/modules/event.cpp
+++ b/test/modules/event.cpp
@@ -6,7 +6,7 @@ IMPORT_FSTR(eventSnap, PROJECT_DIR "/out/jerryscript/event.js.snap")
 DEFINE_FSTR(testEventName, "EVENT_TEMP")
 HashMap<String, Vector<JS::Callable>> events;
 
-JS_DEFINE_FUNCTION(addEventListener, 2, JS::Value& eventName, JS::Callable& function)
+JS_DEFINE_FUNCTION(addEventListener, JS::Value& eventName, JS::Callable& function)
 {
 	if(!eventName.isString() || !function.isCallable()) {
 		return JS::ArgumentError(__FUNCTION__);

--- a/test/modules/fatal.cpp
+++ b/test/modules/fatal.cpp
@@ -5,7 +5,7 @@ namespace
 IMPORT_FSTR(fatalSnap, PROJECT_DIR "/out/jerryscript/fatal.js.snap")
 IMPORT_FSTR(fatalEsNextSnap, PROJECT_DIR "/files/fatal.es.next.js.snap")
 
-JS_DEFINE_FUNCTION(throwTantrum, 1, JS::Value& reason)
+JS_DEFINE_FUNCTION(throwTantrum, JS::Value& reason)
 {
 	// todo
 	return true;


### PR DESCRIPTION
Simplify use of JS_DEFINE_xxx macros by deducing parameter count.