### PR TITLE
Add watchdog and ContextList

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -31,4 +31,8 @@ menu "JerryScript"
         help
             Required for use of :cpp:func:`Jerryscript::eval` function.
 
+    config JERRY_EXTERNAL_CONTEXT
+        bool "Enable external contexts for fully isolated containers"
+        default N
+
 endmenu

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,16 @@ invalid reference counts, for example, which will cause :cpp:func:`Jerryscript::
 Applications should generally be built with this setting disabled (the default).
 
 
+External Contexts
+-----------------
+
+By default, a single, global VM context is created in which all code is loaded and executed.
+If multiple javascript applications are running then if one fails it will take out all the others.
+
+Enabling the :envvar:`JERRY_EXTERNAL_CONTEXT` setting allows use of the :cpp:class:`JS::Context`
+class to run multiple isolated instances. See the :sample:`Basic_Context` example for details.
+
+
 Configuration variables
 -----------------------
 
@@ -121,6 +131,13 @@ Configuration variables
 
    Enable to build library with javascript parser enabled.
    Required for use of :cpp:func:`Jerryscript::eval` function.
+
+
+.. envvar:: JERRY_EXTERNAL_CONTEXT
+
+   default: 0 (disabled)
+
+   Enable this setting to make use of :cpp:class:`JS::Context` to run multiple isolated instances.
 
 
 .. envvar:: JERRY_GLOBAL_HEAP_SIZE

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,27 @@ invalid reference counts, for example, which will cause :cpp:func:`Jerryscript::
 Applications should generally be built with this setting disabled (the default).
 
 
+Watchdog
+--------
+
+Sming is a single-threaded framework so requires co-operation to perform :doc:`multi-tasking </information/multitasking>`.
+This means javascript calls should be brief so as not to disrupt the system.
+
+If a javascript call takes too long then the system watchdog will timeout and reset the system.
+This is generally not helpful, so a separate watchdog is implemented for the Jerryscript virtual machine.
+
+By default, the watchdog is disabled. To enable it, add a call during initialisation:
+
+.. code-block:: c++
+
+   // Enable the watchdog with a 100ms timeout (0 to disable it)
+   JS::Watchdog::setPeriod(100);
+
+Now, if a call takes more than 100ms then a fatal error will be thrown as discussed above.
+
+The setting can be changed at any time and is unaffected by jerryscript engine resets.
+
+
 External Contexts
 -----------------
 

--- a/component.mk
+++ b/component.mk
@@ -2,15 +2,16 @@
 COMPONENT_SUBMODULES := jerryscript
 
 JERRYSCRIPT_ROOT := $(COMPONENT_PATH)/jerryscript
+JERRYSCRIPT_SRCDIRS := $(call ListAllSubDirs,$(JERRYSCRIPT_ROOT)/jerry-core)
 
 COMPONENT_SRCDIRS := \
 	src \
-	$(call ListAllSubDirs,$(JERRYSCRIPT_ROOT)/jerry-core)
+	$(JERRYSCRIPT_SRCDIRS)
 
 COMPONENT_INCDIRS := \
 	src/include \
 	$(JERRYSCRIPT_ROOT)/jerry-core \
-	$(COMPONENT_SRCDIRS)
+	$(JERRYSCRIPT_SRCDIRS)
 
 COMPONENT_DOCFILES := jerryscript/docs/img/engines_high_level_design.png
 COMPONENT_DOXYGEN_INPUT := src/include

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -154,3 +154,43 @@ index 19ec199f..fd578b2a 100644
  
  /**
   * Get snapshot configuration flags.
+diff --git a/jerry-core/vm/vm.c b/jerry-core/vm/vm.c
+index 13cbd7ec..28748935 100644
+--- a/jerry-core/vm/vm.c
++++ b/jerry-core/vm/vm.c
+@@ -41,6 +41,12 @@
+ #include "opcodes.h"
+ #include "vm-stack.h"
+ 
++#ifdef SMING_ARCH
++#include <jerry_port_vm.h>
++#else
++#define jerry_port_watchdog_poll() true
++#endif
++
+ /** \addtogroup vm Virtual machine
+  * @{
+  *
+@@ -1023,7 +1029,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
+   while (true)
+   {
+     /* Internal loop for byte code execution. */
+-    while (true)
++    while (jerry_port_watchdog_poll())
+     {
+       const uint8_t *byte_code_start_p = byte_code_p;
+       uint8_t opcode = *byte_code_p++;
+diff --git a/jerry-core/include/jerryscript-port.h b/jerry-core/include/jerryscript-port.h
+index 91bb3fe3..1f0f1d35 100644
+--- a/jerry-core/include/jerryscript-port.h
++++ b/jerry-core/include/jerryscript-port.h
+@@ -48,7 +48,8 @@ typedef enum
+   ERR_REF_COUNT_LIMIT = 12,
+   ERR_DISABLED_BYTE_CODE = 13,
+   ERR_UNTERMINATED_GC_LOOPS = 14,
+-  ERR_FAILED_INTERNAL_ASSERTION = 120
++  ERR_FAILED_INTERNAL_ASSERTION = 120,
++  ERR_WATCHDOG_TIMEOUT = 150, // Custom Sming code
+ } jerry_fatal_code_t;
+ 
+ /**

--- a/samples/Advanced_Jsvm/component.mk
+++ b/samples/Advanced_Jsvm/component.mk
@@ -1,6 +1,6 @@
 COMPONENT_DEPENDS := MultipartParser jerryscript
 
-HWCONFIG := spiffs
+HWCONFIG := spiffs-2m
 DEV_FILES := files/web
 SPIFF_FILES := out/web
 APP_JS_SOURCE_DIR := files/js

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "include/Jerryscript/Types.h"
+#include "include/jerry_port_vm.h"
 #include <debug_progmem.h>
 
 extern "C" {
@@ -223,6 +224,19 @@ Error::operator String() const
 Object Value::toObject() const
 {
 	return OwnedValue{jerry_value_to_object(get())};
+}
+
+Value Callable::call(const Object& thisValue, const Value& arg)
+{
+	jerry_port_watchdog_reset();
+	return OwnedValue{jerry_call_function(get(), thisValue.get(), &const_cast<Value&>(arg).get(), 1)};
+}
+
+Value Callable::call(const Object& thisValue, std::initializer_list<Value> args)
+{
+	jerry_port_watchdog_reset();
+	return OwnedValue{
+		jerry_call_function(get(), thisValue.get(), args.size() ? &args.begin()->get() : nullptr, args.size())};
 }
 
 } // namespace Jerryscript

--- a/src/include/Jerryscript/Except.h
+++ b/src/include/Jerryscript/Except.h
@@ -10,7 +10,7 @@
  *
  */
 
-#include "include/Jerryscript/Types.h"
+#include "Types.h"
 #include <csetjmp>
 
 namespace Jerryscript

--- a/src/include/Jerryscript/Types.h
+++ b/src/include/Jerryscript/Types.h
@@ -990,21 +990,14 @@ public:
 	/**
 	 * @brief Call with one argument
 	 */
-	Value call(const Object& thisValue, const Value& arg)
-	{
-		return OwnedValue{jerry_call_function(get(), thisValue.get(), &const_cast<Value&>(arg).get(), 1)};
-	}
+	Value call(const Object& thisValue, const Value& arg);
 
 	/**
 	 * @brief Call with zero or multiple arguments
 	 *
 	 * e.g. `call(myObject, {1, 2, 3});`
 	 */
-	Value call(const Object& thisValue, std::initializer_list<Value> args = {})
-	{
-		return OwnedValue{
-			jerry_call_function(get(), thisValue.get(), args.size() ? &args.begin()->get() : nullptr, args.size())};
-	}
+	Value call(const Object& thisValue, std::initializer_list<Value> args = {});
 
 	/**
 	 * @brief Get specific type of callable object

--- a/src/include/Jerryscript/VirtualMachine.h
+++ b/src/include/Jerryscript/VirtualMachine.h
@@ -13,6 +13,7 @@
 
 #include "Types.h"
 #include <FileSystem.h>
+#include <Platform/Clocks.h>
 
 namespace Jerryscript
 {
@@ -38,6 +39,23 @@ inline bool isFeatureEnabled(Feature feature)
 {
 	return jerry_is_feature_enabled(jerry_feature_t(feature));
 }
+
+namespace Watchdog
+{
+/**
+ * @brief Set watchdog period
+ * @param milliseconds Timeout period, use 0 to disable
+ */
+void setPeriod(unsigned milliseconds);
+
+/**
+ * @brief Get elapsed watchdog time since last reset
+ * @retval uint32_t Time in internal timer ticks
+ * @note For debugging and inspection use only
+ */
+Timer2Clock::Ticks<uint32_t> read();
+
+}; // namespace Watchdog
 
 /*
  * @brief Parses the JavaScript code and prepares it for execution

--- a/src/include/jerry_port_vm.h
+++ b/src/include/jerry_port_vm.h
@@ -1,0 +1,62 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * jerry_port_vm.h - Additional Sming port functions used by jerryscript VM
+ *
+ * @author: Dec 2021 - Mikee47 <mike@sillyhouse.net>
+ *
+ */
+
+#pragma once
+
+#include <driver/hw_timer.h>
+#include <jrt.h>
+
+/**
+ * @brief Watchdog state information
+ */
+struct jerry_port_watchdog_t {
+	uint32_t period; ///< Watchdog timeout in hardware timer units
+	uint32_t start;  ///< Time of last call to jerry_port_watchdog_reset()
+};
+
+extern struct jerry_port_watchdog_t jerry_port_watchdog;
+
+/**
+ * @brief Set watchdog period in milliseconds
+ */
+void jerry_port_watchdog_set_period(uint32_t milliseconds);
+
+/**
+ * @brief Reset watchdog timer before calling into jerryscript (load, run, etc)
+ */
+__forceinline static void jerry_port_watchdog_reset()
+{
+	jerry_port_watchdog.start = hw_timer2_read();
+}
+
+/**
+ * @brief Get elapsed watchdog time (in ticks) since last reset
+ */
+__forceinline static uint32_t jerry_port_watchdog_read()
+{
+	return hw_timer2_read() - jerry_port_watchdog.start;
+}
+
+/**
+ * @brief Called by jerryscript VM loop. Generates fatal error on timeout.
+ */
+__forceinline static bool jerry_port_watchdog_poll()
+{
+	if(jerry_port_watchdog.period == 0) {
+		return true;
+	}
+	if(jerry_port_watchdog_read() < jerry_port_watchdog.period) {
+		return true;
+	}
+	jerry_fatal(ERR_WATCHDOG_TIMEOUT);
+	return false;
+}

--- a/src/jerry-port.cpp
+++ b/src/jerry-port.cpp
@@ -16,8 +16,16 @@
 #include "include/Jerryscript/Context.h"
 #include <include/jerryscript-port.h>
 #include <include/jerryscript-core.h>
+#include "include/jerry_port_vm.h"
 #include <debug_progmem.h>
 #include <Platform/RTC.h>
+
+struct jerry_port_watchdog_t jerry_port_watchdog;
+
+void jerry_port_watchdog_set_period(uint32_t milliseconds)
+{
+	jerry_port_watchdog.period = uint64_t(milliseconds) * HW_TIMER2_CLK / 1000U;
+}
 
 /**
  * Provide log message implementation for the engine.

--- a/test/files/fatal.js
+++ b/test/files/fatal.js
@@ -12,3 +12,9 @@ function allocateArray(count, value, dbg) {
 
 	return true;
 }
+
+function infiniteLoop() {
+	while (true) {
+		// Help! Watchdog save me please!
+	}
+}

--- a/test/include/modules.h
+++ b/test/include/modules.h
@@ -1,14 +1,13 @@
 // List of test modules to register
 
-// Assertions prevent testing of fatal error paths
 #ifdef JERRY_ENABLE_DEBUG
 #define TEST_MAP_DEBUG(XX)
 #else
-#define TEST_MAP_DEBUG(XX) XX(fatal)
+#define TEST_MAP_DEBUG(XX)
 #endif
 
 #define TEST_MAP(XX)                                                                                                   \
-	TEST_MAP_DEBUG(XX)                                                                                                 \
+	XX(fatal)                                                                                                          \
 	XX(types)                                                                                                          \
 	XX(event)                                                                                                          \
 	XX(parser)                                                                                                         \

--- a/test/modules/fatal.cpp
+++ b/test/modules/fatal.cpp
@@ -86,5 +86,8 @@ public:
 
 void REGISTER_TEST(fatal)
 {
+// Assertions prevent testing of fatal error paths
+#ifndef JERRY_ENABLE_DEBUG
 	registerGroup<FatalTest>();
+#endif
 }

--- a/test/modules/parser.cpp
+++ b/test/modules/parser.cpp
@@ -16,6 +16,8 @@ public:
 		TEST_CASE("eval")
 		{
 			REQUIRE(JS::eval("12 + 7 * 3").as<int>() == 33);
+			auto wdtElapsed = JS::Watchdog::read().as<NanoTime::Microseconds>();
+			debug_i("JS watchdog %s", wdtElapsed.toString().c_str());
 		}
 
 #ifdef JERRY_ESNEXT


### PR DESCRIPTION
As Sming is not pre-emptively multitasked, a mechanism is required to catch scripts which might otherwise block or lock up the system.
This PR adds a watchdog which applications may use to limit the time for any call into jerryscript.
When the watchdog fires, a fatal error is generated.

In addition, servicing multiple contexts should be done via the task queue to ensure smooth operation.
The `ContextList` template class has been added to simplify this process.
