### PR TITLE
Fix 'maybe unitialized' error

### DIFF
--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -207,3 +207,16 @@ index 36c02277..94d0934f 100644
    switch (code)
    {
      case ERR_OUT_OF_MEMORY:
+diff --git a/jerry-core/ecma/base/ecma-helpers-string.c b/jerry-core/ecma/base/ecma-helpers-string.c
+index 12770f36..5ab67df2 100644
+--- a/jerry-core/ecma/base/ecma-helpers-string.c
++++ b/jerry-core/ecma/base/ecma-helpers-string.c
+@@ -1835,7 +1835,7 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /**< ecma-st
+                                     const ecma_string_t *string2_p) /**< ecma-string */
+ {
+   const lit_utf8_byte_t *utf8_string1_p, *utf8_string2_p;
+-  lit_utf8_size_t string1_size_and_length[2], string2_size_and_length[2];
++  lit_utf8_size_t string1_size_and_length[2]={0}, string2_size_and_length[2]={0};
+ 
+   utf8_string1_p = ecma_compare_get_string_chars (string1_p, string1_size_and_length);
+   utf8_string2_p = ecma_compare_get_string_chars (string2_p, string2_size_and_length);


### PR DESCRIPTION
Building with recent compilers flags the following error:

```
Sming/Libraries/jerryscript/jerryscript/jerry-core/ecma/base/ecma-helpers-string.c:1848:6:
error: ‘string1_size_and_length[0]’ may be used uninitialized [-Werror=maybe-uninitialized]
1848 |   if (string1_size_and_length[0] != string2_size_and_length[0]
````
