### PR TITLE
Update jerryscript to 3.0.0

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -25,18 +25,16 @@ JERRY_GLOBAL_HEAP_SIZE ?= 1
 
 # Compact (minimal profile) compilation profile makes the JerryScript library smaller
 COMPONENT_VARS += JERRY_COMPACT_PROFILE
-JERRY_COMPACT_PROFILE ?= 1
+JERRY_COMPACT_PROFILE ?= 0
 
 ifeq ($(JERRY_COMPACT_PROFILE),1)
 JERRY_PROFILE := minimal
 # Apply these flags to library and tool(s)
 JERRY_COMPILER_FLAGS := \
 	JERRY_BUILTINS=0 \
-	JERRY_ESNEXT=0 \
 	JERRY_UNICODE_CASE_CONVERSION=0
 else
 JERRY_PROFILE := es.next
-GLOBAL_CFLAGS += -DJERRY_ESNEXT=1
 endif
 
 JERRY_WEB_COMPILER := $(COMPONENT_PATH)/jsc/$(JERRY_PROFILE)

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -181,3 +181,35 @@ index 3bb753c2..473e03e4 100644
  tests/test262/
  .vs
 +out/
+diff --git a/jerry-port/win/jerry-port-win-process.c b/jerry-port/win/jerry-port-win-process.c
+index c567da8a..40f88d24 100644
+--- a/jerry-port/win/jerry-port-win-process.c
++++ b/jerry-port/win/jerry-port-win-process.c
+@@ -18,7 +18,7 @@
+ 
+ #include <windows.h>
+ 
+-#include <crtdbg.h>
++// #include <crtdbg.h>
+ #include <stdio.h>
+ 
+ void
+@@ -71,12 +71,12 @@ jerry_port_init (void)
+      * This is C runtime specific and thus the above incantations aren't
+      * sufficient to suppress these popups.
+      */
+-    _CrtSetReportMode (_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+-    _CrtSetReportFile (_CRT_ERROR, _CRTDBG_FILE_STDERR);
+-    _CrtSetReportMode (_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+-    _CrtSetReportFile (_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+-    _CrtSetReportMode (_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+-    _CrtSetReportFile (_CRT_WARN, _CRTDBG_FILE_STDERR);
++    // _CrtSetReportMode (_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
++    // _CrtSetReportFile (_CRT_ERROR, _CRTDBG_FILE_STDERR);
++    // _CrtSetReportMode (_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
++    // _CrtSetReportFile (_CRT_ASSERT, _CRTDBG_FILE_STDERR);
++    // _CrtSetReportMode (_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
++    // _CrtSetReportFile (_CRT_WARN, _CRTDBG_FILE_STDERR);
+   }
+ } /* jerry_port_init */
+ 

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -1,8 +1,8 @@
 diff --git a/jerry-core/parser/js/js-parser.c b/jerry-core/parser/js/js-parser.c
-index b55baed5..bd6b41da 100644
+index 8f241b6a..2734b2c5 100644
 --- a/jerry-core/parser/js/js-parser.c
 +++ b/jerry-core/parser/js/js-parser.c
-@@ -3356,12 +3356,9 @@ parser_parse_script (void *source_p, /**< source code */
+@@ -3360,12 +3360,8 @@ parser_parse_script (void *source_p, /**< source code */
  
    return bytecode_p;
  #else /* !JERRY_PARSER */
@@ -11,30 +11,15 @@ index b55baed5..bd6b41da 100644
    JERRY_UNUSED (source_p);
 -  JERRY_UNUSED (source_size);
    JERRY_UNUSED (parse_opts);
--  JERRY_UNUSED (resource_name);
-+  JERRY_UNUSED (options_p);
+-  JERRY_UNUSED (source_name);
  
    ecma_raise_syntax_error (ECMA_ERR_PARSER_NOT_SUPPORTED);
    return NULL;
-diff --git a/jerry-core/ecma/operations/ecma-eval.c b/jerry-core/ecma/operations/ecma-eval.c
-index e4a2d734..cd544844 100644
---- a/jerry-core/ecma/operations/ecma-eval.c
-+++ b/jerry-core/ecma/operations/ecma-eval.c
-@@ -94,8 +94,7 @@ ecma_op_eval_chars_buffer (void *source_p, /**< source code */
- 
-   return vm_run_eval (bytecode_p, parse_opts);
- #else /* !JERRY_PARSER */
--  JERRY_UNUSED (code_p);
--  JERRY_UNUSED (code_buffer_size);
-+  JERRY_UNUSED (source_p);
-   JERRY_UNUSED (parse_opts);
- 
-   return ecma_raise_syntax_error (ECMA_ERR_PARSER_NOT_SUPPORTED);
 diff --git a/jerry-core/ecma/base/ecma-helpers.c b/jerry-core/ecma/base/ecma-helpers.c
-index bd25d9d3..cce169bb 100644
+index c51be10d..151ec37a 100644
 --- a/jerry-core/ecma/base/ecma-helpers.c
 +++ b/jerry-core/ecma/base/ecma-helpers.c
-@@ -1626,11 +1626,13 @@ ecma_script_get_from_value (ecma_value_t value) /**< compiled code */
+@@ -1616,11 +1616,13 @@ ecma_script_get_from_value (ecma_value_t value) /**< compiled code */
        {
          ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
  
@@ -49,27 +34,27 @@ index bd25d9d3..cce169bb 100644
  #if JERRY_MODULE_SYSTEM
          if (ext_object_p->u.cls.type == ECMA_OBJECT_CLASS_MODULE)
 diff --git a/jerry-core/api/jerryscript.c b/jerry-core/api/jerryscript.c
-index 13e3fd65..32444cd6 100644
+index d8174b92..1ceb0373 100644
 --- a/jerry-core/api/jerryscript.c
 +++ b/jerry-core/api/jerryscript.c
-@@ -564,10 +564,12 @@ jerry_run (const jerry_value_t func_val) /**< function to run */
+@@ -534,10 +534,12 @@ jerry_run (const jerry_value_t script) /**< script or module to run */
  
-   ecma_object_t *object_p = ecma_get_object_from_value (func_val);
+   ecma_object_t *object_p = ecma_get_object_from_value (script);
  
 +#if JERRY_PARSER
    if (!ecma_object_class_is (object_p, ECMA_OBJECT_CLASS_SCRIPT))
    {
-     return jerry_throw (ecma_raise_type_error (ECMA_ERR_WRONG_ARGS_MSG));
+     return jerry_throw_sz (JERRY_ERROR_TYPE, ecma_get_error_msg (ECMA_ERR_WRONG_ARGS_MSG));
    }
 +#endif
  
    ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
  
 diff --git a/jerry-core/jmem/jmem-heap.c b/jerry-core/jmem/jmem-heap.c
-index 152909a6..200f61d7 100644
+index b7e60849..c3177506 100644
 --- a/jerry-core/jmem/jmem-heap.c
 +++ b/jerry-core/jmem/jmem-heap.c
-@@ -734,6 +734,7 @@ jmem_heap_get_stats (jmem_heap_stats_t *out_heap_stats_p) /**< [out] heap stats
+@@ -744,6 +744,7 @@ jmem_heap_get_stats (jmem_heap_stats_t *out_heap_stats_p) /**< [out] heap stats
  void
  jmem_heap_stats_print (void)
  {
@@ -77,19 +62,19 @@ index 152909a6..200f61d7 100644
    jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
  
    JERRY_DEBUG_MSG ("Heap stats:\n");
-@@ -764,6 +765,7 @@ jmem_heap_stats_print (void)
-                    heap_stats->peak_object_bytes,
-                    heap_stats->property_bytes,
-                    heap_stats->peak_property_bytes);
+@@ -762,6 +763,7 @@ jmem_heap_stats_print (void)
+   JERRY_DEBUG_MSG ("  Peak allocated object data = %u bytes\n", (unsigned) heap_stats->peak_object_bytes);
+   JERRY_DEBUG_MSG ("  Allocated property data = %u bytes\n", (unsigned) heap_stats->property_bytes);
+   JERRY_DEBUG_MSG ("  Peak allocated property data = %u bytes\n", (unsigned) heap_stats->peak_property_bytes);
 +#endif
  } /* jmem_heap_stats_print */
  
  /**
 diff --git a/jerry-core/jrt/jrt.h b/jerry-core/jrt/jrt.h
-index ffd4bde3..dc0ee760 100644
+index 2c1f308d..8a760809 100644
 --- a/jerry-core/jrt/jrt.h
 +++ b/jerry-core/jrt/jrt.h
-@@ -24,6 +24,12 @@
+@@ -25,6 +25,12 @@
  #include "config.h"
  #include "jrt-types.h"
  
@@ -102,7 +87,7 @@ index ffd4bde3..dc0ee760 100644
  /*
   * Constants
   */
-@@ -78,14 +84,14 @@ void JERRY_ATTR_NORETURN jerry_unreachable (const char *file, const char *functi
+@@ -79,14 +85,14 @@ void JERRY_ATTR_NORETURN jerry_unreachable (const char *file, const char *functi
    {                                                         \
      if (JERRY_UNLIKELY (!(x)))                              \
      {                                                       \
@@ -119,43 +104,23 @@ index ffd4bde3..dc0ee760 100644
    } while (0)
  #else /* JERRY_NDEBUG */
  #define JERRY_ASSERT(x) \
-@@ -120,10 +126,10 @@ void JERRY_ATTR_NORETURN jerry_fatal (jerry_fatal_code_t code);
+@@ -124,10 +130,10 @@ void jerry_jrt_set_log_level (jerry_log_level_t level);
   * Logging
   */
  #if JERRY_LOGGING
--#define JERRY_ERROR_MSG(...)   jerry_port_log (JERRY_LOG_LEVEL_ERROR, __VA_ARGS__)
--#define JERRY_WARNING_MSG(...) jerry_port_log (JERRY_LOG_LEVEL_WARNING, __VA_ARGS__)
--#define JERRY_DEBUG_MSG(...)   jerry_port_log (JERRY_LOG_LEVEL_DEBUG, __VA_ARGS__)
--#define JERRY_TRACE_MSG(...)   jerry_port_log (JERRY_LOG_LEVEL_TRACE, __VA_ARGS__)
-+#define JERRY_ERROR_MSG(fmt, ...)   jerry_port_log (JERRY_LOG_LEVEL_ERROR, _F(fmt), ##__VA_ARGS__)
-+#define JERRY_WARNING_MSG(fmt, ...) jerry_port_log (JERRY_LOG_LEVEL_WARNING, _F(fmt), ##__VA_ARGS__)
-+#define JERRY_DEBUG_MSG(fmt, ...)   jerry_port_log (JERRY_LOG_LEVEL_DEBUG, _F(fmt), ##__VA_ARGS__)
-+#define JERRY_TRACE_MSG(fmt, ...)   jerry_port_log (JERRY_LOG_LEVEL_TRACE, _F(fmt), ##__VA_ARGS__)
+-#define JERRY_ERROR_MSG(...)   jerry_log (JERRY_LOG_LEVEL_ERROR, __VA_ARGS__)
+-#define JERRY_WARNING_MSG(...) jerry_log (JERRY_LOG_LEVEL_WARNING, __VA_ARGS__)
+-#define JERRY_DEBUG_MSG(...)   jerry_log (JERRY_LOG_LEVEL_DEBUG, __VA_ARGS__)
+-#define JERRY_TRACE_MSG(...)   jerry_log (JERRY_LOG_LEVEL_TRACE, __VA_ARGS__)
++#define JERRY_ERROR_MSG(fmt, ...)   jerry_log (JERRY_LOG_LEVEL_ERROR, _F(fmt), ##__VA_ARGS__)
++#define JERRY_WARNING_MSG(fmt, ...) jerry_log (JERRY_LOG_LEVEL_WARNING, _F(fmt), ##__VA_ARGS__)
++#define JERRY_DEBUG_MSG(fmt, ...)   jerry_log (JERRY_LOG_LEVEL_DEBUG, _F(fmt), ##__VA_ARGS__)
++#define JERRY_TRACE_MSG(fmt, ...)   jerry_log (JERRY_LOG_LEVEL_TRACE, _F(fmt), ##__VA_ARGS__)
  #else /* !JERRY_LOGGING */
  #define JERRY_ERROR_MSG(...)          \
    do                                  \
-diff --git a/jerry-core/api/jerry-snapshot.c b/jerry-core/api/jerry-snapshot.c
-index 19ec199f..fd578b2a 100644
---- a/jerry-core/api/jerry-snapshot.c
-+++ b/jerry-core/api/jerry-snapshot.c
-@@ -33,6 +33,7 @@
- 
- #if JERRY_SNAPSHOT_SAVE || JERRY_SNAPSHOT_EXEC
- 
-+#if JERRY_SNAPSHOT_SAVE
- /**
-  * Create an error object
-  *
-@@ -49,6 +50,7 @@ jerry_create_error_from_id (jerry_error_t error_type, /**< type of error */
- {
-   return jerry_create_error (error_type, (jerry_char_t *) ecma_get_error_utf8 (msg));
- } /* jerry_create_error_from_id */
-+#endif
- 
- /**
-  * Get snapshot configuration flags.
 diff --git a/jerry-core/vm/vm.c b/jerry-core/vm/vm.c
-index 13cbd7ec..28748935 100644
+index b6e1e88f..2ab657fe 100644
 --- a/jerry-core/vm/vm.c
 +++ b/jerry-core/vm/vm.c
 @@ -41,6 +41,12 @@
@@ -171,7 +136,7 @@ index 13cbd7ec..28748935 100644
  /** \addtogroup vm Virtual machine
   * @{
   *
-@@ -1023,7 +1029,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
+@@ -1018,7 +1024,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
    while (true)
    {
      /* Internal loop for byte code execution. */
@@ -181,21 +146,21 @@ index 13cbd7ec..28748935 100644
        const uint8_t *byte_code_start_p = byte_code_p;
        uint8_t opcode = *byte_code_p++;
 diff --git a/jerry-core/include/jerryscript-port.h b/jerry-core/include/jerryscript-port.h
-index 91bb3fe3..1f0f1d35 100644
+index e3187371..c522ec04 100644
 --- a/jerry-core/include/jerryscript-port.h
 +++ b/jerry-core/include/jerryscript-port.h
-@@ -48,7 +48,8 @@ typedef enum
-   ERR_REF_COUNT_LIMIT = 12,
-   ERR_DISABLED_BYTE_CODE = 13,
-   ERR_UNTERMINATED_GC_LOOPS = 14,
--  ERR_FAILED_INTERNAL_ASSERTION = 120
-+  ERR_FAILED_INTERNAL_ASSERTION = 120,
-+  ERR_WATCHDOG_TIMEOUT = 150, // Custom Sming code
+@@ -46,7 +46,8 @@ typedef enum
+   JERRY_FATAL_REF_COUNT_LIMIT = 12, /**< Reference count limit reached */
+   JERRY_FATAL_DISABLED_BYTE_CODE = 13, /**< Executed disabled instruction */
+   JERRY_FATAL_UNTERMINATED_GC_LOOPS = 14, /**< Garbage collection loop limit reached */
+-  JERRY_FATAL_FAILED_ASSERTION = 120 /**< Assertion failed */
++  JERRY_FATAL_FAILED_ASSERTION = 120, /**< Assertion failed */
++  JERRY_FATAL_WATCHDOG_TIMEOUT = 150, /**< Custom Sming code */
  } jerry_fatal_code_t;
  
  /**
 diff --git a/jerry-core/jrt/jrt-fatals.c b/jerry-core/jrt/jrt-fatals.c
-index 36c02277..94d0934f 100644
+index c2e09488..53e5e3fc 100644
 --- a/jerry-core/jrt/jrt-fatals.c
 +++ b/jerry-core/jrt/jrt-fatals.c
 @@ -29,7 +29,7 @@
@@ -206,17 +171,13 @@ index 36c02277..94d0934f 100644
 +#if 0
    switch (code)
    {
-     case ERR_OUT_OF_MEMORY:
-diff --git a/jerry-core/ecma/base/ecma-helpers-string.c b/jerry-core/ecma/base/ecma-helpers-string.c
-index 12770f36..5ab67df2 100644
---- a/jerry-core/ecma/base/ecma-helpers-string.c
-+++ b/jerry-core/ecma/base/ecma-helpers-string.c
-@@ -1835,7 +1835,7 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /**< ecma-st
-                                     const ecma_string_t *string2_p) /**< ecma-string */
- {
-   const lit_utf8_byte_t *utf8_string1_p, *utf8_string2_p;
--  lit_utf8_size_t string1_size_and_length[2], string2_size_and_length[2];
-+  lit_utf8_size_t string1_size_and_length[2]={0}, string2_size_and_length[2]={0};
- 
-   utf8_string1_p = ecma_compare_get_string_chars (string1_p, string1_size_and_length);
-   utf8_string2_p = ecma_compare_get_string_chars (string2_p, string2_size_and_length);
+     case JERRY_FATAL_OUT_OF_MEMORY:
+diff --git a/.gitignore b/.gitignore
+index 3bb753c2..473e03e4 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -39,3 +39,4 @@ docs/doxygen
+ # Tests
+ tests/test262/
+ .vs
++out/

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -213,3 +213,37 @@ index c567da8a..40f88d24 100644
    }
  } /* jerry_port_init */
  
+diff --git a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+index db90bc93..8810bf0c 100644
+--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
++++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+@@ -175,8 +175,8 @@ typedef enum
+ } ecma_date_timezone_t;
+ 
+ /* ecma-builtin-helpers-date.c */
+-extern const char day_names_p[7][3];
+-extern const char month_names_p[12][3];
++extern const char day_names_p[7][4];
++extern const char month_names_p[12][4];
+ 
+ int32_t ecma_date_day_from_time (ecma_number_t time);
+ int32_t ecma_date_year_from_time (ecma_number_t time);
+diff --git a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+index 280a94c4..fd5233b5 100644
+--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
++++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+@@ -36,12 +36,12 @@
+ /**
+  * Day names
+  */
+-const char day_names_p[7][3] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
++const char day_names_p[7][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+ 
+ /**
+  * Month names
+  */
+-const char month_names_p[12][3] = {
++const char month_names_p[12][4] = {
+   "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+ };
+ 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -22,8 +22,7 @@ Context::Context() : Context(JERRY_GLOBAL_HEAP_SIZE * 1024)
 
 Context::Context(size_t heapSize)
 {
-	auto ctx = jerry_create_context(std::max(heapSize, size_t(1024U)), alloc, this);
-	context.reset(reinterpret_cast<uint8_t*>(ctx));
+	context = std::make_unique<uint8_t[]>(std::max(heapSize, size_t(1024U)));
 }
 
 void* Context::alloc(size_t size, void* param)

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -15,7 +15,7 @@ namespace Jerryscript
 bool printHeap()
 {
 	jerry_heap_stats_t stats;
-	if(!jerry_get_memory_stats(&stats)) {
+	if(!jerry_heap_stats(&stats)) {
 		m_printf(_F("[JS] Heap stats disabled"));
 		return false;
 	}

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -101,8 +101,8 @@ Value::Value(unsigned value) : value(ecma_make_uint32_value(value))
 
 size_t Value::readString(unsigned offset, char* buffer, size_t length) const
 {
-	return jerry_substring_to_char_buffer(value, offset, offset + length, reinterpret_cast<jerry_char_t*>(buffer),
-										  length);
+	jerry_value_t substr = jerry_string_substr(value, offset, offset + length);
+	return jerry_string_to_buffer(substr, JERRY_ENCODING_UTF8, reinterpret_cast<jerry_char_t*>(buffer), length);
 }
 
 String Value::subString(unsigned offset, size_t length) const
@@ -127,20 +127,20 @@ Value::operator String() const
 		return nullptr;
 	}
 
-	jerry_size_t sz = jerry_get_string_size(strval.get());
+	jerry_size_t sz = jerry_string_size(strval.get(), JERRY_ENCODING_UTF8);
 	String s;
 	if(!s.setLength(sz)) {
 		return nullptr;
 	}
 
-	jerry_string_to_char_buffer(strval.get(), reinterpret_cast<jerry_char_t*>(s.begin()), sz);
+	jerry_string_to_buffer(strval.get(), JERRY_ENCODING_UTF8, reinterpret_cast<jerry_char_t*>(s.begin()), sz);
 
 	return s;
 }
 
 Array Object::keys() const
 {
-	return OwnedValue{jerry_get_object_keys(get())};
+	return OwnedValue{jerry_object_keys(get())};
 }
 
 Callable Object::getFunction(const String& name)
@@ -200,7 +200,7 @@ Value Object::runFunction(const String& name, std::initializer_list<Value> args)
 
 Value Error::message() const
 {
-	Object value = OwnedValue{jerry_get_value_from_error(get(), false)};
+	Object value = OwnedValue{jerry_throw_value(get(), false)};
 	return value[F("message")];
 }
 
@@ -229,14 +229,13 @@ Object Value::toObject() const
 Value Callable::call(const Object& thisValue, const Value& arg)
 {
 	jerry_port_watchdog_reset();
-	return OwnedValue{jerry_call_function(get(), thisValue.get(), &const_cast<Value&>(arg).get(), 1)};
+	return OwnedValue{jerry_call(get(), thisValue.get(), &const_cast<Value&>(arg).get(), 1)};
 }
 
 Value Callable::call(const Object& thisValue, std::initializer_list<Value> args)
 {
 	jerry_port_watchdog_reset();
-	return OwnedValue{
-		jerry_call_function(get(), thisValue.get(), args.size() ? &args.begin()->get() : nullptr, args.size())};
+	return OwnedValue{jerry_call(get(), thisValue.get(), args.size() ? &args.begin()->get() : nullptr, args.size())};
 }
 
 } // namespace Jerryscript

--- a/src/include/Jerryscript/Debug.h
+++ b/src/include/Jerryscript/Debug.h
@@ -17,7 +17,7 @@ using HeapStats = jerry_heap_stats_t;
 
 inline bool getHeapStats(HeapStats& stats)
 {
-	return jerry_get_memory_stats(&stats);
+	return jerry_heap_stats(&stats);
 }
 
 size_t getHeapUsed();

--- a/src/include/Jerryscript/Except.h
+++ b/src/include/Jerryscript/Except.h
@@ -12,7 +12,7 @@
 
 #include "Types.h"
 #include <csetjmp>
-#include <jerryscript-port.h>
+#include <jerry-core/include/jerryscript-port.h>
 
 namespace Jerryscript
 {

--- a/src/include/Jerryscript/Except.h
+++ b/src/include/Jerryscript/Except.h
@@ -12,6 +12,7 @@
 
 #include "Types.h"
 #include <csetjmp>
+#include <jerryscript-port.h>
 
 namespace Jerryscript
 {

--- a/src/include/Jerryscript/Types.h
+++ b/src/include/Jerryscript/Types.h
@@ -145,8 +145,8 @@ class Callable;
  *
  * IMPORTANT: When dealing with raw/native values, **ALWAYS** use either `OwnedValue` or `CopyValue` casts.
  * 
- *   - This is correct:  Value value = OwnedValue{jerry_create_object()};
- *   - This is wrong:    Value value = jerry_create_object(); // Ends up with memory leak plus garbage
+ *   - This is correct:  Value value = OwnedValue{jerry_object()};
+ *   - This is wrong:    Value value = jerry_object(); // Ends up with memory leak plus garbage
  *
  */
 class Value
@@ -171,7 +171,7 @@ public:
 	/**
 	 * @brief Construct a Value using a copy (or reference to) the given native value
 	 */
-	Value(const CopyValue& value) : value(jerry_acquire_value(value.value))
+	Value(const CopyValue& value) : value(jerry_value_copy(value.value))
 	{
 	}
 
@@ -224,28 +224,29 @@ public:
 	/**
 	 * @brief floating-point
 	 */
-	Value(double value) : value(jerry_create_number(value))
+	Value(double value) : value(jerry_number(value))
 	{
 	}
 
 	/**
 	 * @brief Boolean
 	 */
-	Value(bool value) : value(jerry_create_boolean(value))
+	Value(bool value) : value(jerry_boolean(value))
 	{
 	}
 
 	/**
 	 * @brief Wiring String
 	 */
-	Value(const String& s) : value(jerry_create_string_sz(reinterpret_cast<const jerry_char_t*>(s.c_str()), s.length()))
+	Value(const String& s)
+		: value(jerry_string(reinterpret_cast<const jerry_char_t*>(s.c_str()), s.length(), JERRY_ENCODING_UTF8))
 	{
 	}
 
 	/**
 	 * @brief NUL-terminated 'C' string
 	 */
-	Value(const char* s) : value(jerry_create_string(reinterpret_cast<const jerry_char_t*>(s)))
+	Value(const char* s) : value(jerry_string_sz(s))
 	{
 	}
 
@@ -289,7 +290,7 @@ public:
 	Value& reset(jerry_value_t value = jerry_value_t(Ecma::VALUE_EMPTY))
 	{
 		if(!isEmpty()) {
-			jerry_release_value(this->value);
+			jerry_value_free(this->value);
 		}
 		this->value = value;
 		return *this;
@@ -436,7 +437,7 @@ public:
 	 */
 	Type type() const
 	{
-		return Type(jerry_value_get_type(value));
+		return Type(jerry_value_type(value));
 	}
 
 	/**
@@ -497,12 +498,12 @@ public:
 
 		operator float() const
 		{
-			return jerry_get_number_value(v.get());
+			return jerry_value_as_number(v.get());
 		}
 
 		operator double() const
 		{
-			return jerry_get_number_value(v.get());
+			return jerry_value_as_number(v.get());
 		}
 
 		operator String() const
@@ -538,7 +539,7 @@ private:
 class ExternalFunction : public Value
 {
 public:
-	ExternalFunction(jerry_external_handler_t handler) : Value(OwnedValue{jerry_create_external_function(handler)})
+	ExternalFunction(jerry_external_handler_t handler) : Value(OwnedValue{jerry_function_external(handler)})
 	{
 	}
 };
@@ -593,7 +594,7 @@ public:
 	/**
 	 * @brief Default constructor creates a new, empty object
 	 */
-	Object() : Value(OwnedValue{jerry_create_object()})
+	Object() : Value(OwnedValue{jerry_object()})
 	{
 	}
 
@@ -634,7 +635,7 @@ public:
 	 */
 	Value setProperty(const Value& name, const Value& value)
 	{
-		return OwnedValue{jerry_set_property(get(), name.get(), value.get())};
+		return OwnedValue{jerry_object_set(get(), name.get(), value.get())};
 	}
 
 	/**
@@ -644,7 +645,7 @@ public:
 	 */
 	Value getProperty(const Value& name) const
 	{
-		return OwnedValue{jerry_get_property(get(), name.get())};
+		return OwnedValue{jerry_object_get(get(), name.get())};
 	}
 
 	/**
@@ -654,7 +655,7 @@ public:
 	 */
 	bool hasProperty(const Value& name) const
 	{
-		return jerry_has_property(get(), name.get());
+		return jerry_object_has(get(), name.get());
 	}
 
 	/**
@@ -664,7 +665,7 @@ public:
 	 */
 	bool removeProperty(const Value& name)
 	{
-		return jerry_delete_property(get(), name.get());
+		return jerry_object_delete(get(), name.get());
 	}
 	/** @} */
 
@@ -733,7 +734,7 @@ public:
 	/**
 	 * @brief Error with type only
 	 */
-	Error(ErrorType type) : Value(OwnedValue{jerry_create_error_sz(jerry_error_t(type), nullptr, 0)})
+	Error(ErrorType type) : Value(OwnedValue{jerry_error_sz(jerry_error_t(type), nullptr)})
 	{
 	}
 
@@ -741,8 +742,7 @@ public:
 	 * @brief Error with type and message
 	 */
 	Error(ErrorType type, const String& message)
-		: Value(OwnedValue{jerry_create_error_sz(
-			  jerry_error_t(type), reinterpret_cast<const jerry_char_t*>(message.c_str()), message.length())})
+		: Value(OwnedValue{jerry_error_sz(jerry_error_t(type), message.c_str())})
 	{
 	}
 	/** @} */
@@ -766,7 +766,7 @@ public:
 	 */
 	ErrorType errorType() const
 	{
-		return ErrorType(jerry_get_error_type(get()));
+		return ErrorType(jerry_error_type(get()));
 	}
 
 	/**
@@ -909,7 +909,7 @@ public:
 	/**
 	 * @brief Create a new, fixed-size array with the given number of elements
 	 */
-	Array(size_t size) : Object(OwnedValue{jerry_create_array(size)})
+	Array(size_t size) : Object(OwnedValue{jerry_array(size)})
 	{
 	}
 
@@ -918,7 +918,7 @@ public:
 	 */
 	size_t count() const
 	{
-		return jerry_get_array_length(get());
+		return jerry_array_length(get());
 	}
 
 	/**
@@ -967,7 +967,7 @@ public:
 	 */
 	Value getProperty(unsigned index) const
 	{
-		return OwnedValue{jerry_get_property_by_index(get(), index)};
+		return OwnedValue{jerry_object_get_index(get(), index)};
 	}
 
 	/**
@@ -978,7 +978,7 @@ public:
 	 */
 	Value setProperty(unsigned index, const Value& value)
 	{
-		return OwnedValue{jerry_set_property_by_index(get(), index, value.get())};
+		return OwnedValue{jerry_object_set_index(get(), index, value.get())};
 	}
 	/** @} */
 };
@@ -1010,7 +1010,7 @@ public:
 	 */
 	FunctionType functionType() const
 	{
-		return FunctionType(jerry_function_get_type(get()));
+		return FunctionType(jerry_function_type(get()));
 	}
 };
 
@@ -1019,7 +1019,7 @@ public:
  */
 inline Object global()
 {
-	return OwnedValue{jerry_get_global_object()};
+	return OwnedValue{jerry_current_realm()};
 }
 
 } // namespace Jerryscript

--- a/src/include/Jerryscript/VirtualMachine.h
+++ b/src/include/Jerryscript/VirtualMachine.h
@@ -37,7 +37,7 @@ void cleanup();
  */
 inline bool isFeatureEnabled(Feature feature)
 {
-	return jerry_is_feature_enabled(jerry_feature_t(feature));
+	return jerry_feature_enabled(jerry_feature_t(feature));
 }
 
 namespace Watchdog
@@ -112,7 +112,7 @@ inline Value loadFromFile(const String& fileName)
  */
 inline void gc(bool maximumEffort = false)
 {
-	jerry_gc(maximumEffort ? JERRY_GC_PRESSURE_HIGH : JERRY_GC_PRESSURE_LOW);
+	jerry_heap_gc(maximumEffort ? JERRY_GC_PRESSURE_HIGH : JERRY_GC_PRESSURE_LOW);
 }
 
 } // namespace Jerryscript

--- a/src/include/jerry_port_vm.h
+++ b/src/include/jerry_port_vm.h
@@ -57,6 +57,6 @@ __forceinline static bool jerry_port_watchdog_poll()
 	if(jerry_port_watchdog_read() < jerry_port_watchdog.period) {
 		return true;
 	}
-	jerry_fatal(ERR_WATCHDOG_TIMEOUT);
+	jerry_fatal(JERRY_FATAL_WATCHDOG_TIMEOUT);
 	return false;
 }

--- a/src/jerry-port.cpp
+++ b/src/jerry-port.cpp
@@ -30,25 +30,18 @@ void jerry_port_watchdog_set_period(uint32_t milliseconds)
 /**
  * Provide log message implementation for the engine.
  */
-void jerry_port_log(jerry_log_level_t level, /**< log level */
-					const char* format,		 /**< format string */
-					...)					 /**< parameters */
+void jerry_port_log(const char* msg)
 {
-	(void)level; /* ignore log level */
-
-	va_list args;
-	va_start(args, format);
-	m_vprintf(format, args);
-	va_end(args);
+	m_puts(msg);
 }
 
 /**
- * Default implementation of jerry_port_get_current_time.
+ * Default implementation of jerry_port_current_time.
  */
-double jerry_port_get_current_time()
+double jerry_port_current_time()
 {
 	return RTC.getRtcNanoseconds() / 1e9;
-} /* jerry_port_get_current_time */
+}
 
 /**
  * Default implementation of jerry_port_get_local_time_zone_adjustment. Uses the 'tm_gmtoff' field
@@ -61,7 +54,22 @@ double jerry_port_get_current_time()
 double jerry_port_get_local_time_zone_adjustment(double unix_ms, /**< ms since unix epoch */
 												 bool is_utc)	/**< is the time above in UTC? */
 {
+	// TODO
 	return 0.0;
+}
+
+/**
+ * Get the current system time in UTC.
+ *
+ * This port function is called by jerry-core when JERRY_BUILTIN_DATE is enabled.
+ * It can also be used in the implementing application to initialize the random number generator.
+ *
+ * @return milliseconds since Unix epoch
+ */
+int32_t jerry_port_local_tza(double unix_ms)
+{
+	// TODO
+	return 0;
 }
 
 /**
@@ -88,12 +96,28 @@ jerry_value_t jerry_port_module_resolve(const jerry_value_t specifier, /**< modu
 	return jerry_error(JERRY_ERROR_REFERENCE, {});
 }
 
+size_t jerry_port_context_alloc(size_t context_size)
+{
+	return context_size;
+}
+
+void jerry_port_context_free(void)
+{
+}
+
 /**
  * Get the current context.
  *
  * @return the pointer to the current context
  */
-jerry_context_t* jerry_port_get_current_context(void)
+jerry_context_t* jerry_port_context_get(void)
 {
 	return Jerryscript::Context::getCurrent();
+}
+
+/**
+ * Init the program
+ */
+void jerry_port_init(void)
+{
 }

--- a/src/jerry-port.cpp
+++ b/src/jerry-port.cpp
@@ -85,7 +85,7 @@ jerry_value_t jerry_port_module_resolve(const jerry_value_t specifier, /**< modu
 	(void)referrer;
 	(void)user_p;
 
-	return jerry_create_error(JERRY_ERROR_REFERENCE, nullptr);
+	return jerry_error(JERRY_ERROR_REFERENCE, {});
 }
 
 /**

--- a/test/component.mk
+++ b/test/component.mk
@@ -33,14 +33,12 @@ APP_CFLAGS += -DRESTART_DELAY=$(RESTART_DELAY)
 
 define BuildAndRun
 +$(MAKE) snap-clean config-clean
-+$(MAKE) MODULE="$(patsubst %/test,%/,$(MODULE))$1.$3" JERRY_COMPACT_PROFILE=$2 JERRY_ENABLE_DEBUG=$4 $5 run
++$(MAKE) MODULE="$(patsubst %/test,%/,$(MODULE))$1.$2" JERRY_ENABLE_DEBUG=$3 $4 run
 endef
 
 .PHONY: execute
 execute:
-	$(call BuildAndRun,minimal,1,debug,1)
-	$(call BuildAndRun,minimal,1,release,0)
-	$(call BuildAndRun,es.next,0,debug,1)
-	$(call BuildAndRun,es.next,0,release,0)
-	$(call BuildAndRun,parser,0,release,0,JERRY_PARSER=1)
-	$(call BuildAndRun,context,0,release,0,JERRY_EXTERNAL_CONTEXT=1)
+	$(call BuildAndRun,es.next,debug,1)
+	$(call BuildAndRun,es.next,release,0)
+	$(call BuildAndRun,parser,release,0,JERRY_PARSER=1)
+	$(call BuildAndRun,context,release,0,JERRY_EXTERNAL_CONTEXT=1)

--- a/test/modules/event.cpp
+++ b/test/modules/event.cpp
@@ -1,8 +1,9 @@
 #include <JerryTest.h>
 
+IMPORT_FSTR_LOCAL(eventSnap, PROJECT_DIR "/out/jerryscript/event.js.snap")
+
 namespace
 {
-IMPORT_FSTR(eventSnap, PROJECT_DIR "/out/jerryscript/event.js.snap")
 DEFINE_FSTR(testEventName, "EVENT_TEMP")
 HashMap<String, Vector<JS::Callable>> events;
 

--- a/test/modules/fatal.cpp
+++ b/test/modules/fatal.cpp
@@ -1,10 +1,10 @@
 #include <JerryTest.h>
 
+IMPORT_FSTR_LOCAL(fatalSnap, PROJECT_DIR "/out/jerryscript/fatal.js.snap")
+IMPORT_FSTR_LOCAL(fatalEsNextSnap, PROJECT_DIR "/files/fatal.es.next.js.snap")
+
 namespace
 {
-IMPORT_FSTR(fatalSnap, PROJECT_DIR "/out/jerryscript/fatal.js.snap")
-IMPORT_FSTR(fatalEsNextSnap, PROJECT_DIR "/files/fatal.es.next.js.snap")
-
 JS_DEFINE_FUNCTION(throwTantrum, JS::Value& reason)
 {
 	// todo


### PR DESCRIPTION
CI is currently failing due to CMake on MacOS, however the current codebase is now nearly 4 years out of date.
This PR is working towards Jerryscript V3 support.

TODO:

* [ ] What's going on with ECMA errors?