### PR TITLE
Fix build errors in MacOS, and with GCC 15.2

### DIFF
--- a/emscripten-snapshot-compiler/CMakeLists.txt
+++ b/emscripten-snapshot-compiler/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 # The name of the files will be jsc.js and jsc.wasm.
 # jsc stands for Jerryscript Snapshot Compiler
 set(EMSCRIPTEN_SNAPSHOT_COMPILER jsc)

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -220,3 +220,81 @@ index 12770f36..5ab67df2 100644
  
    utf8_string1_p = ecma_compare_get_string_chars (string1_p, string1_size_and_length);
    utf8_string2_p = ecma_compare_get_string_chars (string2_p, string2_size_and_length);
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 044a2de8..c7887d10 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ project (Jerry C)
+ 
+ if(NOT DEFINED PYTHON)
+diff --git a/jerry-core/CMakeLists.txt b/jerry-core/CMakeLists.txt
+index cdcb0f49..48605a2c 100644
+--- a/jerry-core/CMakeLists.txt
++++ b/jerry-core/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ set(JERRY_CORE_NAME jerry-core)
+ project (${JERRY_CORE_NAME} C)
+ 
+diff --git a/jerry-ext/CMakeLists.txt b/jerry-ext/CMakeLists.txt
+index e83b8147..6eef1779 100644
+--- a/jerry-ext/CMakeLists.txt
++++ b/jerry-ext/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ set(JERRY_EXT_NAME jerry-ext)
+ project (${JERRY_EXT_NAME} C)
+ 
+diff --git a/jerry-main/CMakeLists.txt b/jerry-main/CMakeLists.txt
+index ccd62f4e..ff3dc80e 100644
+--- a/jerry-main/CMakeLists.txt
++++ b/jerry-main/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ project (jerry-main C)
+ 
+ # Optional build settings
+diff --git a/jerry-math/CMakeLists.txt b/jerry-math/CMakeLists.txt
+index 4b5bba49..30177e9c 100644
+--- a/jerry-math/CMakeLists.txt
++++ b/jerry-math/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ set(JERRY_MATH_NAME jerry-math)
+ project (${JERRY_MATH_NAME} C)
+ 
+diff --git a/jerry-port/default/CMakeLists.txt b/jerry-port/default/CMakeLists.txt
+index 17f3d478..7ac841e5 100644
+--- a/jerry-port/default/CMakeLists.txt
++++ b/jerry-port/default/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.10)
+ set(JERRY_PORT_DEFAULT_NAME jerry-port-default)
+ project (${JERRY_PORT_DEFAULT_NAME} C)
+ 

--- a/jerryscript.patch
+++ b/jerryscript.patch
@@ -298,3 +298,37 @@ index 17f3d478..7ac841e5 100644
  set(JERRY_PORT_DEFAULT_NAME jerry-port-default)
  project (${JERRY_PORT_DEFAULT_NAME} C)
  
+diff --git a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+index db90bc93..8810bf0c 100644
+--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
++++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+@@ -175,8 +175,8 @@ typedef enum
+ } ecma_date_timezone_t;
+ 
+ /* ecma-builtin-helpers-date.c */
+-extern const char day_names_p[7][3];
+-extern const char month_names_p[12][3];
++extern const char day_names_p[7][4];
++extern const char month_names_p[12][4];
+ 
+ int32_t ecma_date_day_from_time (ecma_number_t time);
+ int32_t ecma_date_year_from_time (ecma_number_t time);
+diff --git a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+index 280a94c4..fd5233b5 100644
+--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
++++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+@@ -36,12 +36,12 @@
+ /**
+  * Day names
+  */
+-const char day_names_p[7][3] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
++const char day_names_p[7][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+ 
+ /**
+  * Month names
+  */
+-const char month_names_p[12][3] = {
++const char month_names_p[12][4] = {
+   "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+ };
+ 

--- a/samples/Basic_Context/app/application.cpp
+++ b/samples/Basic_Context/app/application.cpp
@@ -1,6 +1,8 @@
 #include <SmingCore.h>
 #include <Jerryscript.h>
 
+IMPORT_FSTR_LOCAL(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
+
 namespace
 {
 /*
@@ -62,7 +64,6 @@ private:
 
 JS::ContextList<MyContext> contexts;
 SimpleTimer timer;
-IMPORT_FSTR(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
 
 /*
  * Called at startup to initialise our jerryscript engine,

--- a/samples/Basic_Jsvm/app/application.cpp
+++ b/samples/Basic_Jsvm/app/application.cpp
@@ -1,11 +1,11 @@
 #include <SmingCore.h>
 #include <Jerryscript.h>
 
+IMPORT_FSTR_LOCAL(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
+
 namespace
 {
 JS::Task task;
-
-IMPORT_FSTR(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
 
 void startJsvm()
 {

--- a/samples/Event_Jsvm/app/application.cpp
+++ b/samples/Event_Jsvm/app/application.cpp
@@ -1,12 +1,12 @@
 #include <SmingCore.h>
 #include <Jerryscript.h>
 
+IMPORT_FSTR_LOCAL(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
+
 namespace
 {
 SimpleTimer timer;
 HashMap<String, JS::Callable::List> events;
-
-IMPORT_FSTR(main_snap, PROJECT_DIR "/out/jerryscript/main.js.snap")
 
 /**
  * @brief Function to register event listeners

--- a/test/modules/context.cpp
+++ b/test/modules/context.cpp
@@ -1,9 +1,9 @@
 #include <JerryTest.h>
 
+IMPORT_FSTR_LOCAL(contextSnap, PROJECT_DIR "/out/jerryscript/context.js.snap")
+
 namespace
 {
-IMPORT_FSTR(contextSnap, PROJECT_DIR "/out/jerryscript/context.js.snap")
-
 class Context : public JS::ContextTemplate<Context>
 {
 public:

--- a/test/modules/event.cpp
+++ b/test/modules/event.cpp
@@ -1,8 +1,9 @@
 #include <JerryTest.h>
 
+IMPORT_FSTR_LOCAL(eventSnap, PROJECT_DIR "/out/jerryscript/event.js.snap")
+
 namespace
 {
-IMPORT_FSTR(eventSnap, PROJECT_DIR "/out/jerryscript/event.js.snap")
 DEFINE_FSTR(testEventName, "EVENT_TEMP")
 HashMap<String, Vector<JS::Callable>> events;
 

--- a/test/modules/fatal.cpp
+++ b/test/modules/fatal.cpp
@@ -1,10 +1,10 @@
 #include <JerryTest.h>
 
+IMPORT_FSTR_LOCAL(fatalSnap, PROJECT_DIR "/out/jerryscript/fatal.js.snap")
+IMPORT_FSTR_LOCAL(fatalEsNextSnap, PROJECT_DIR "/files/fatal.es.next.js.snap")
+
 namespace
 {
-IMPORT_FSTR(fatalSnap, PROJECT_DIR "/out/jerryscript/fatal.js.snap")
-IMPORT_FSTR(fatalEsNextSnap, PROJECT_DIR "/files/fatal.es.next.js.snap")
-
 JS_DEFINE_FUNCTION(throwTantrum, JS::Value& reason)
 {
 	// todo


### PR DESCRIPTION
This PR provides some maintenance fixes for the follow issues:

- Patch CMake minimum version < 3.10: CI build is failing on MacOS
- Fix missing IMPORT_FSTR data building with GCC 15.2
- `day_names_p` and `month_names_p` ill-defined
