### PR TITLE
Fix MacOS enum conversion build errors

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -94,6 +94,9 @@ JERRY_CMAKE_PARAMS := \
 	--compile-flag "-I $(JERRYSCRIPT_ROOT)/../src/include" \
 	--compile-flag "-Wno-error=unused-parameter " \
 	--compile-flag "-D_POSIX_C_SOURCE=1 -U__STRICT_ANSI__"
+else ifeq ($(UNAME),Darwin)
+JERRY_CMAKE_PARAMS := \
+	--compile-flag "-Wno-enum-enum-conversion "
 endif
 
 $(JERRY_SNAPSHOT_TOOL):


### PR DESCRIPTION
CI is getting errors because code relies on intrinsic conversion of enum to int. This is broken MacOS so this PR suppresses such warnings. Example:

```
jerryscript/jerry-core/api/jerryscript.c:86:56:
error: arithmetic between different enumeration types ('jerry_binary_operation_t' and 'number_arithmetic_op')
[-Werror,-Wenum-enum-conversion]
   86 | JERRY_STATIC_ASSERT (((NUMBER_ARITHMETIC_SUBTRACTION + ECMA_NUMBER_ARITHMETIC_OP_API_OFFSET) == JERRY_BIN_OP_SUB)
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
